### PR TITLE
改正CSTR域名并改进封面

### DIFF
--- a/example2025.bib
+++ b/example2025.bib
@@ -2017,7 +2017,8 @@ OPTIONS={labelnumber=true},
   publisher = {国家青藏高原科学数据中心},
   year      = {2012},
   urldate   = {2025-07-15},
-  url       = {https://poles.tpdc.ac.cn/zh-hans/data/f92a4346-a33f-497d-9470-2b357ccb4246/. DOI:10.3972/alacier001.2013.db}
+  url       = {https://poles.tpdc.ac.cn/zh-hans/data/f92a4346-a33f-497d-9470-2b357ccb4246/},
+  doi       = {10.3972/alacier001.2013.db}
 }
 
 @dataset{仲晓雅2022夜间灯光,
@@ -2056,7 +2057,8 @@ OPTIONS={labelnumber=true},
   publisher = {Science data bank},
   date      = {2018-05-26},
   urldate   = {2025-02-14},
-  url       = {https://cstr.cn/31253.11.sciencedb.610. DOI:10.11922/sciencedb.610}
+  url       = {https://cstr.cn/31253.11.sciencedb.610},
+  doi       = {10.11922/sciencedb.610},
 }
 
 

--- a/gb7714-2025.bbx
+++ b/gb7714-2025.bbx
@@ -2141,7 +2141,7 @@
 \DeclareFieldFormat{cstr}{%
   \rmfamily{CSTR}\addcolon\space
   \ifhyperref
-    {\href{https://cstr.org/#1}{\nolinkurl{#1}}}
+    {\href{https://cstr.cn/#1}{\nolinkurl{#1}}}
     {\nolinkurl{#1}}}
 %
 %   标题的字母大小写格式修改

--- a/gb7714-2025ay.bbx
+++ b/gb7714-2025ay.bbx
@@ -2182,7 +2182,7 @@
 \DeclareFieldFormat{cstr}{%
   \rmfamily{CSTR}\addcolon\space
   \ifhyperref
-    {\href{https://cstr.org/#1}{\nolinkurl{#1}}}
+    {\href{https://cstr.cn/#1}{\nolinkurl{#1}}}
     {\nolinkurl{#1}}}
 %
 %   标题的字母大小写格式修改

--- a/gbT7714-2025.tex
+++ b/gbT7714-2025.tex
@@ -271,7 +271,7 @@ gbfootbib=true,gbalign=gb7714-2015,autolang=other*]{biblatex}%sorting=nyt,casech
     \draw (0mm, -65mm) -- (170mm, -65mm);
     \node at (85mm, -105mm) {\parbox{150mm}{\centering\zihao{1}\heiti\usename}};
     \node at (85mm, -121mm) {\parbox{150mm}{\centering\zihao{4}\heiti\useenname}};
-    \node at (85mm, -133mm) {\makebox[0pt][c]{\zihao{4}\heiti\useconformity}};
+    \node at (85mm, -150mm) {\makebox[0pt][c]{\zihao{4}\heiti\useconformity}};
     \end{tikzpicture}
     \vfill
     % \hskip-1.2mm%
@@ -287,19 +287,19 @@ gbfootbib=true,gbalign=gb7714-2015,autolang=other*]{biblatex}%sorting=nyt,casech
 }
 
 
-\title{信息与文献\ \ 参考文献著录规则\footnote{说明：本文档为GB/T 7714-2025的简单复现版本，作为GB/T 7714-2025 中的著录标准和顺序编码制示例，用于gb7714-2025样式更新后与GB/T 7714-2025标准文档的内容进行比较，以确定更新没有引入样式方面的BUG，对比文档为stdgbT7714-2025.pdf，该文档经过多次比较，明确与GB/T 7714-2025中的示例完全一致。}}
+\title{信息与文献\ \ 参考文献著录规则\footnote{说明：本文档为GB/T 7714—2025的简单复现版本，作为GB/T 7714—2025 中的著录标准和顺序编码制示例，用于gb7714-2025样式更新后与GB/T 7714—2025标准文档的内容进行比较，以确定更新没有引入样式方面的BUG。对比文档stdgbT7714-2025.pdf经过多次比较，其示例应该与GB/T 7714—2025一致（个别已注明区别除外）。}}
 \author{}
 \date{}
 
 % use parameters
 \ICS{ICS 01.140.20}
 \fenlei{CCS A 14}
-\biaozhunhao{GB/T 7714~\rule[.3\ccwd]{.8em}{.5pt}~2025}
-\daitibiaozhunhao{代替：GB/T 7714~\rule[.3\ccwd]{.8em}{.5pt}~2015}
+\biaozhunhao{GB/T 7714—2025}
+\daitibiaozhunhao{代替 GB/T 7714—2015}
 \name{信息与文献\ \ 参考文献著录规则}
-\enname{Information and documentation--Rules for bibliographic references
+\enname{Information and documentation---Rules for bibliographic references
 and citations to information resources}
-\conformity{}
+\conformity{本文档为简单复现版本，用于更新参考文献样式后回归测试}
 \department{\parbox{11\ccwd}{国家市场监督管理总局\\
 国家标准化管理委员会}}
 \fabudate{2025-12-02}


### PR DESCRIPTION
- **改正CSTR域名（cstr.org → cstr.cn）和`example2025.bib`几处错误字段**

  其实`example2025.bib`仍存在下面这样的问题条目，[人工智能查出来不少](https://chat.deepseek.com/share/qqtux4njbk9eizemoh)；不过都没被引用，我就没改。
  https://github.com/hushidong/biblatex-gb7714-2025/blob/a68cfcd1b9b44523f1b7257eefda82707b9da306/example2025.bib#L4809-L4812
  

- **改进封面，注明不是国标原件**

	<details>
	<summary>新封面截图</summary>
	
	<img width="631" height="830" alt="图片" src="https://github.com/user-attachments/assets/fdce570d-2148-4f6d-b1f0-f543a6c27e75" />
	
	</details>

## 新发现的差异

7 著录通则 → 7.1.2 著作方式相同的责任者…… → 示例4：国标用空白分隔名字，而复刻版用逗号。
不过此处仅展示如何著录责任者，应该没有影响，不用修改。

## 其它问题

我查了一下警告，发现除了一大堆 Invalid format of date field 'date' - ignoring（比如光绪某某年），还有以下三个警告；不过编译结果好像没问题。

```log
Package biblatex: 'babel/polyglossia' detected but 'csquotes' missing.
(biblatex)	Loading 'csquotes' recommended.

Package babel: No hyphenation patterns were preloaded for
(babel)	the language 'French' into the format.
(babel)	Please, configure your TeX system to add them and
(babel)	rebuild the format. Now I will use the patterns
(babel)	preloaded for \language=nohyphenation instead.

Package babel: No hyphenation patterns were preloaded for
(babel)	the language 'Russian' into the format.
(babel)	Please, configure your TeX system to add them and
(babel)	rebuild the format. Now I will use the patterns
(babel)	preloaded for \language=0 instead.
```
